### PR TITLE
bump omniauth dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,35 @@
 PATH
   remote: .
   specs:
-    omniauth-snowflake (0.1.1)
-      omniauth (~> 1.0)
-      omniauth-oauth2 (~> 1.1)
+    omniauth-snowflake (0.1.2)
+      omniauth (~> 1.2)
+      omniauth-oauth2 (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (0.8.8)
-      multipart-post (~> 1.2.0)
-    hashie (2.0.5)
-    httpauth (0.2.0)
-    jwt (0.1.8)
-      multi_json (>= 1.5)
-    multi_json (1.7.9)
-    multipart-post (1.2.0)
-    oauth2 (0.8.1)
-      faraday (~> 0.8)
-      httpauth (~> 0.1)
-      jwt (~> 0.1.4)
-      multi_json (~> 1.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    hashie (3.4.1)
+    jwt (1.4.1)
+    multi_json (1.11.0)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
       rack (~> 1.2)
-    omniauth (1.1.4)
-      hashie (>= 1.2, < 3)
-      rack
-    omniauth-oauth2 (1.1.1)
-      oauth2 (~> 0.8.0)
-      omniauth (~> 1.0)
-    rack (1.5.2)
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
+    omniauth-oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      multi_json (~> 1.3)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
+    rack (1.6.0)
 
 PLATFORMS
   ruby

--- a/lib/omniauth-snowflake/version.rb
+++ b/lib/omniauth-snowflake/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Snowflake
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/omniauth-snowflake.gemspec
+++ b/omniauth-snowflake.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Snowflake::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.1'
+  gem.add_dependency 'omniauth', '~> 1.2'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.2'
 end


### PR DESCRIPTION
this unpins us from quite an old version of oauth2 which causes friction
w/ other gem integrations. plus good to stay up to date w/ these
dependencies in general.
